### PR TITLE
WIP: adapt control tower to native API

### DIFF
--- a/awsapilib/authentication/authentication.py
+++ b/awsapilib/authentication/authentication.py
@@ -415,55 +415,6 @@ class Authenticator(BaseAuthenticator):   # pylint: disable=too-many-instance-at
                   'SigninToken': self._get_signin_token()}
         return f'{self.urls.federation}?{urllib.parse.urlencode(params)}'
 
-    def get_control_tower_authenticated_session(self):
-        """Authenticates to control tower and returns an authenticated session.
-
-        Returns:
-            session (requests.Session): An authenticated session with headers and cookies set.
-
-        """
-        service = 'controltower'
-        self._session.get(self.get_signed_url())
-        url = f'{self.urls.regional_console}/{service}/home'
-        host = urllib.parse.urlparse(url)[1]
-        self.logger.debug('Setting host to: %s', host)
-        self._get_response(url,
-                           params={'region': self.region},
-                           extra_cookies=[FilterCookie('JSESSIONID'),
-                                          FilterCookie('aws-userInfo-signed')])
-        hash_args = self._get_response(url,
-                                       params={'state': 'hashArgs#'},
-                                       extra_cookies=[FilterCookie('JSESSIONID', self.urls.regional_console),
-                                                      FilterCookie('aws-userInfo-signed',),
-                                                      FilterCookie('aws-creds-code-verifier', self.urls.regional_console
-                                                                   )])
-        oauth = self._get_response(hash_args.headers.get('Location'),
-                                   extra_cookies=[FilterCookie('JSESSIONID', self.urls.regional_console),
-                                                  FilterCookie('aws-creds', self.domains.sign_in),
-                                                  FilterCookie('aws-userInfo-signed', ),
-                                                  FilterCookie('aws-creds-code-verifier', f'/{service}')],)
-        oauth_challenge = self._get_response(oauth.headers.get('Location'),
-                                             extra_cookies=[FilterCookie('JSESSIONID', self.urls.regional_console),
-                                                            FilterCookie('aws-userInfo-signed',),
-                                                            FilterCookie('aws-creds', self.domains.sign_in),
-                                                            FilterCookie('aws-creds-code-verifier', f'/{service}')])
-        self._get_response(oauth_challenge.headers.get('Location'),
-                           extra_cookies=[FilterCookie('aws-creds', f'/{service}'),
-                                          FilterCookie('JSESSIONID', host),
-                                          FilterCookie('aws-userInfo-signed')])
-        dashboard = self._get_response(url,
-                                       params={'region': self.region},
-                                       extra_cookies=[FilterCookie('aws-creds', f'/{service}'),
-                                                      FilterCookie('JSESSIONID', host),
-                                                      FilterCookie('aws-consoleInfo'),
-                                                      FilterCookie('aws-userInfo-signed')])
-        csrf_token_data = CsrfTokenData(entity_type='meta',
-                                        attributes={'name': 'awsc-csrf-token'},
-                                        attribute_value='content',
-                                        headers_name='X-CSRF-TOKEN')
-        extra_cookies = [FilterCookie('JSESSIONID', self.domains.regional_console),
-                         FilterCookie('aws-creds', f'{self.domains.regional_console}/{service}')]
-        return self._get_session_from_console(dashboard, csrf_token_data, extra_cookies)
 
     def get_sso_authenticated_session(self):
         """Authenticates to Single Sign On and returns an authenticated session.

--- a/awsapilib/controltower/controltower.py
+++ b/awsapilib/controltower/controltower.py
@@ -223,9 +223,8 @@ class ControlTower(LoggerMixin):  # pylint: disable=too-many-instance-attributes
         if self._core_accounts is None:
             core_accounts = []
             for account_type in self.core_account_types:
-                payload = self._get_api_payload(content_string={'AccountType': account_type},
-                                                target='describeCoreService')
-                response = self.session.post(self.url, json=payload)
+                payload = {'AccountType': account_type}
+                response = self.call('DescribeCoreService', payload)
                 if not response.ok:
                     raise ServiceCallFailed(f'Service call failed with payload {payload}')
                 core_accounts.append(CoreAccount(self, account_type, response.json()))
@@ -1335,10 +1334,7 @@ class ControlTower(LoggerMixin):  # pylint: disable=too-many-instance-attributes
             response (bool): True if the process starts successfully, False otherwise.
 
         """
-        payload = self._get_api_payload(content_string={},
-                                        target='deleteLandingZone',
-                                        region=self.region)
-        response = self.session.post(self.url, json=payload)
+        response = self.call('DeleteLandingZone')
         if not response.ok:
             self.logger.error('Failed to decommission control tower with response status "%s" and response text "%s"',
                               response.status_code, response.text)


### PR DESCRIPTION
Control Tower has dark launched an official API and is rolling out a new AWS Console backend which makes use of the API, so this makes `awsapilib` ControlTower APIs failing.

This PR adapts to the new native APIs.